### PR TITLE
Update dependencies and minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.12.4
+  - 2.12.7
 
 jdk:
   - oraclejdk8
@@ -12,10 +12,11 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 
-script:
-  ## This runs the template with the default parameters, and runs test within the templated app.
-  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
 
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+script:
+  ## This generates a new project inside `target/sbt-test/` applying the assuming the `src/main/g8/default.properties`.
+  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M g8

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 CodelyTV staff@codely.tv
+Copyright (c) 2018 CodelyTV staff@codely.tv
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# CodelyTV Scala Bootstrap (g8 template)
+# 🚀 CodelyTV Scala Bootstrap (g8 template)
  
 [![Software License][ico-license]][link-license]
 [![Build Status][ico-travis]][link-travis]
  
-## Introduction 
+## ℹ️ Introduction 
 
 This is a [Giter8][g8] template intended to serve as a starting point if you want to bootstrap a project in Scala.
  
@@ -18,7 +18,7 @@ It could be useful if you want to start a kata, a little exercise or project fro
   * [`.editorconfig`][link-editorconfig]
   * [`.travis.yml`][link-travis-yml]
 
-## How To Start
+## ☝️ How To Start
 
 [Video screencast](http://codely.tv/screencasts/scala-sbt-new/) (in Spanish) 
 
@@ -30,7 +30,7 @@ It could be useful if you want to start a kata, a little exercise or project fro
 
 You can now move to your project's directory, enter the SBT shell with the `sbt` command, and run the test example with `test` or `t`.
 
-## Pre-push Git hook
+## 🤽‍ Pre-push Git hook
 
 There's one Git hook included. It's inside the `doc/hooks` folder and it will run the `prep` SBT task before pushing to any remote.
 
@@ -40,23 +40,24 @@ You can define what this task does modifying the `prep` task in the `build.sbt` 
  
 If you want to install this hook, just `cd doc/hooks` and run `./install-hooks.sh`.
 
-## Other programming languages
+## ☕🐘 Other programming languages
 
+* [Java](https://github.com/CodelyTV/java-bootstrap)
 * [PHP](https://github.com/CodelyTV/php-bootstrap)
 * [Scala](https://github.com/CodelyTV/scala_bootstrap): This other bootstrap is not based in the Gitter8 template system. So you can actually clone the repo and just start coding.
 
-## About
+## ❓ About
 
 This hopefully helpful utility has been developed by [CodelyTV][link-author] and [contributors][link-contributors].
 
 We'll try to maintain this project as simple as possible, but Pull Requests are welcome!
 
-## License
+## ⚖️ License
 
 The MIT License (MIT). Please see [License File][link-license] for more information.
 
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-travis]: https://img.shields.io/travis/CodelyTV/scala_bootstrap/master.svg?style=flat-square
+[ico-travis]: https://img.shields.io/travis/CodelyTV/scala-bootstrap-template.g8/master.svg?style=flat-square
 
 [g8]: http://www.foundweekends.org/giter8/
 [link-license]: LICENSE

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.12.4",
+    scalaVersion := "2.12.7",
     organization := "tv.codely",
     name := "CodelyTV Scala Bootstrap",
-    version := "1.2.0",
+    version := "1.2.1",
     test in Test := {
       val _ = (g8Test in Test).toTask("").value
     },
@@ -11,6 +11,7 @@ lazy val root = (project in file("."))
       "-Xms1024m",
       "-Xmx1024m",
       "-XX:ReservedCodeCacheSize=128m",
+      "-XX:MaxPermSize=256m",
       "-Xss2m",
       "-Dfile.encoding=UTF-8"
     ),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.10.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.11.0")

--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -1,8 +1,16 @@
 style = default
 
-align = true
-
 maxColumn = 120
+
+continuationIndent.callSite = 2
+
+align = more
+
+runner.optimizer.forceConfigStyleMinArgCount = 1
+
+rewrite.rules = [SortImports]
+
+importSelectors = singleLine
 
 project.excludeFilters = ["target/"]
 

--- a/src/main/g8/.travis.yml
+++ b/src/main/g8/.travis.yml
@@ -1,11 +1,22 @@
 language: scala
 
 scala:
-  - 2.12.4
+  - 2.12.7
 
 jdk:
   - oraclejdk8
 
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
 script:
-  ## This runs the template with the default parameters, and runs test within the templated app.
-  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
+  - sbt prep # See `build.sbt` to check out which tasks this alias performs (compile, compile test, style check…)
+  - sbt test

--- a/src/main/g8/LICENSE
+++ b/src/main/g8/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 $organization$ support@$organization$
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -7,14 +7,14 @@ Configuration.settings
 
 /** ********* PROD DEPENDENCIES *****************/
 libraryDependencies ++= Seq(
-  "com.github.nscala-time" %% "nscala-time" % "2.18.0",
+  "com.github.nscala-time" %% "nscala-time" % "2.20.0",
   "com.lihaoyi"            %% "pprint"      % "0.5.3"
 )
 
 /** ********* TEST DEPENDENCIES *****************/
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.4" % Test,
-  "org.scalamock" %% "scalamock" % "4.0.0" % Test
+  "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+  "org.scalamock" %% "scalamock" % "4.1.0" % Test
 )
 
 /** ********* COMMANDS ALIASES ******************/

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,5 @@
-scala_version = 2.12.4
+sbt_version = 1.2.6
+scala_version = 2.12.7
 name = Scala bootstrap
 version = 1.0
 description = Template following Scala best practices in order to bootstrap your environment and be ready for your next kata or project!

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=$sbt_version$

--- a/src/main/g8/project/sbt-scalafmt.sbt
+++ b/src/main/g8/project/sbt-scalafmt.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")


### PR DESCRIPTION
# New improvements/fixes

* Include default MIT `LICENSE` for the generated project
* Parametrized the SBT version to install in the generated project. Defaults to 1.2.6
* Improve ScalaFmt configuration for the generated project
* Fix Travis badge shown in the project `README` pointing to the right Travis repo 😅
* Fix tests running in Travis in order to execute the `g8` task while testing out the templating system

# Updates

* Scala updated to 2.12.7
* SBT for the template project updated to 0.13.17
* sbt-giter8 plugin updated to 0.11.0
* Generated project dependencies updated to their latest versions (nscala-time, scalatest & scalamock)
* sbt-scalafmt updated to 1.5.1